### PR TITLE
[IIIF-946] Use basename of CSV as file name in submitted form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 install:
   - pip install .
 before_script:
-  - pip install black pytest
+  - pip install "black>=19.*,<20.*" pytest
 script:
   - pytest && black --check *.py
 branches:

--- a/bucketeer_cli.py
+++ b/bucketeer_cli.py
@@ -92,7 +92,7 @@ def cli(src, server, failures_only, slack_handle, loglevel, version):
             # Upload the file.
             files = {
                 "file": (
-                    pathstring,
+                    csv_filename,
                     open(pathstring, "rb"),
                     "text/csv",
                     {"Expires": "0"},


### PR DESCRIPTION
Changes:
- supply only the basename of the CSV to the form, not the full path (which causes issues when [Bucketeer derives a job name from it](https://github.com/UCLALibrary/bucketeer/blob/c71f14a71af124b5917925a9ac9fdd13694e7a4b/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java#L119), but is also both irrelevant and a privacy/security issue -- revealing users' filesystem layout)

Reference: https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.name ([PurePath is a subclass of Path](https://docs.python.org/3/library/pathlib.html#pathlib.Path))